### PR TITLE
chore: add pkg.pr.new integration for PR testing

### DIFF
--- a/.github/workflows/new-pr-package.yml
+++ b/.github/workflows/new-pr-package.yml
@@ -1,0 +1,41 @@
+name: Publish Package Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  publish-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+          
+      - name: Install dependencies
+        run: bun install
+        
+      - name: Run linting
+        run: bun run lint
+        
+      - name: Run type checking
+        run: bun run typecheck
+        
+      - name: Run tests
+        run: bun run test
+        
+      - name: Build package
+        run: bun run build
+        
+      - name: Publish to pkg.pr.new
+        run: bunx pkg-pr-new publish --compact --packageManager=bun --comment=update

--- a/README.md
+++ b/README.md
@@ -521,6 +521,32 @@ This package is designed to work seamlessly with TanStack Start projects. Here's
 
 The package automatically discovers routes when they're imported, making it easy to generate comprehensive API documentation.
 
+## Testing Pull Requests
+
+This repository uses [pkg.pr.new](https://pkg.pr.new) to publish preview packages for every pull request, making it easy to test changes before they're merged.
+
+### How to Test a PR
+
+When a pull request is opened, a GitHub Action automatically publishes a preview package. You'll see a comment in the PR with installation instructions:
+
+```bash
+# Install the PR preview package
+npm install https://pkg.pr.new/tanstack-zod-openapi@pr-123
+
+# Or with other package managers
+pnpm add https://pkg.pr.new/tanstack-zod-openapi@pr-123
+bun add https://pkg.pr.new/tanstack-zod-openapi@pr-123
+```
+
+### For Maintainers
+
+The preview package is automatically published when:
+- A new pull request is opened
+- New commits are pushed to an existing PR
+- The main branch receives new commits
+
+The workflow ensures that only PRs with passing tests get published, maintaining quality and reliability.
+
 ## Contributing
 
 Contributions are welcome! Please read our [Contributing Guide](CONTRIBUTING.md) for details on our development process, commit conventions, and how to submit pull requests.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "release:dry": "semantic-release --dry-run",
     "commit": "git add . && git cz",
     "prepare": "lefthook install",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "bun run build",
+    "pr:new": "bunx pr:new publish --compact"
   },
   "keywords": [
     "tanstack",


### PR DESCRIPTION
- Add GitHub Action workflow for automatic package preview publishing
- Configure pkg.pr.new to publish on PRs and main branch commits
- Add documentation section explaining how to test PRs
- Add npm script for manual pkg.pr.new publishing
- Workflow includes quality checks (lint, typecheck, test) before publishing
- Uses compact URLs and automatic comment updates for better UX

This allows contributors and maintainers to easily test package changes from pull requests before merging.

Thanks for the suggestion @spa5k